### PR TITLE
FIX #61: Only remove criteria phrases between parentheses

### DIFF
--- a/form_generator/js/read_standards.js
+++ b/form_generator/js/read_standards.js
@@ -1271,7 +1271,7 @@ function saveFile(){
 						var regex4 = /<\/b>/g;
 						var regex5 = /<b>/g;
 						var regex6 = /[\r\n]+/g;
-						var regex7 =/ \(.+\)/g;
+						var regex7 =/ \(.+?\)/g;
 						var regex8 = /<i>/g;
 						var regex9 = /<\/i>/g;
 


### PR DESCRIPTION
The old regex was greedy and replaced everything between any opening "(" and any closing ")".