### PR TITLE
Fix links to registered reports supplement

### DIFF
--- a/docs/drafts/QualitativeSimulation.md
+++ b/docs/drafts/QualitativeSimulation.md
@@ -58,7 +58,7 @@ Protocol Analysis (AKA protocol studies) are a common type of Qualitative Simula
 <checklist name="Extraordinary">
 
 - [ ]   uses a team-based approach; e.g., multiple raters with analysis of inter-rater reliability (see the [IRR/IRA Supplement](https://github.com/acmsigsoft/EmpiricalStandards/blob/master/docs/supplements/InterRaterReliabilityAndAgreement.md))
-- [ ]   published a protocol beforehand and made it publicly accessible (see the [Registered Reports Supplement](https://github.com/acmsigsoft/EmpiricalStandards/tree/master/docs/supplements)) 
+- [ ]   published a protocol beforehand and made it publicly accessible (see the [Registered Reports Supplement](https://github.com/acmsigsoft/EmpiricalStandards/blob/master/docs/supplements/RegisteredReports.md)) 
 </checklist>
 
     

--- a/docs/standards/CaseStudy.md
+++ b/docs/standards/CaseStudy.md
@@ -82,7 +82,7 @@ captures a large quantitative dataset with limited context, consider the
 
 - [ ]   multiple, deep, fully-developed cases with cross-case triangulation
 - [ ]   uses a team-based approach; e.g., multiple raters with analysis of inter-rater reliability (see the [IRR/IRA Supplement](https://github.com/acmsigsoft/EmpiricalStandards/blob/master/docs/supplements/InterRaterReliabilityAndAgreement.md))
-- [ ]   published a case study protocol beforehand and made it publicly accessible (see the [Registered Reports Supplement](https://github.com/acmsigsoft/EmpiricalStandards/tree/master/docs/supplements)) 
+- [ ]   published a case study protocol beforehand and made it publicly accessible (see the [Registered Reports Supplement](https://github.com/acmsigsoft/EmpiricalStandards/blob/master/docs/supplements/RegisteredReports.md)) 
 </checklist>
     
 ## General Quality Criteria 

--- a/docs/standards/GeneralStandard.md
+++ b/docs/standards/GeneralStandard.md
@@ -91,7 +91,7 @@ following.
 - [ ]	visualizations (e.g. graphs, diagrams, tables) advance the paper’s arguments or contribution
 - [ ]	clarifies the roles and responsibilities of the researchers (i.e. who did what?)
 - [ ]	provides an auto-reflection or assessment of the authors’ own work (e.g. lessons learned)
-- [ ]   publishes the study in two phases: a plan and the results of executing the plan (see the [Registered Reports Supplement](https://github.com/acmsigsoft/EmpiricalStandards/tree/master/docs/supplements)) 
+- [ ]   publishes the study in two phases: a plan and the results of executing the plan (see the [Registered Reports Supplement](https://github.com/acmsigsoft/EmpiricalStandards/blob/master/docs/supplements/RegisteredReports.md)) 
 - [ ]	uses multiple raters, where philosophically appropriate, for making subjective judgments (see the [IRR/IRA Supplement](https://github.com/acmsigsoft/EmpiricalStandards/blob/master/docs/supplements/InterRaterReliabilityAndAgreement.md))
 
 </checklist>


### PR DESCRIPTION
Links to the registered reports supplement now open the supplements page instead of redirecting to the supplements directory on GitHub