### PR TITLE
Fix focus highlight on checklist selection page

### DIFF
--- a/form_generator/index.html
+++ b/form_generator/index.html
@@ -4,7 +4,13 @@
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="stylesheet" href="../form_generator/css/appearance.css">
-        <link rel="stylesheet" href="../form_generator/css/tooltip.css">		
+        <link rel="stylesheet" href="../form_generator/css/tooltip.css">
+
+		<style>
+			input[type=submit]:focus {
+				outline: auto;
+			}
+		</style>	
         
 		<!-- Google tag (gtag.js) -->
 		<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>


### PR DESCRIPTION
Each of the three checklist selections on [this](https://www2.sigsoft.org/EmpiricalStandards/tools/) page now have a visible border when they receive focus for better accessibility

Live example: https://eschltz.github.io/standardstest/tools/