### PR TITLE
Fix footnote-to-tooltip conversion on checklists

### DIFF
--- a/docs/standards/OptimizationStudies.md
+++ b/docs/standards/OptimizationStudies.md
@@ -31,7 +31,7 @@ We stress that the use of optimization in SE is still a rapidly evolving field. 
 - [ ] uses realistic and limited simplifications and constraints for the optimization problem; simplifications and constraints do not reduce the search to one where all solutions could be enumerated through brute force
 - [ ] justifies the choice of algorithm<sup><a class="footnote footnote-ref">5</a></sup> underlying the approach<sup><a class="footnote footnote-ref">6</a></sup>
 - [ ] compares approaches to a justified and appropriate baseline<sup><a class="footnote footnote-ref">7</a></sup>
-- [ ] explictly defines the solution formulation, including a description of what a solution represents<sup><a class="footnote footnote-ref">8</a></sup>, how it is represented<sup><a class="footnote footnote-ref">9</a>)</sup>, and how it is manipulated
+- [ ] explictly defines the solution formulation, including a description of what a solution represents<sup><a class="footnote footnote-ref">8</a></sup>, how it is represented<sup><a class="footnote footnote-ref">9</a></sup>, and how it is manipulated
 - [ ] explicitly defines all fitness functions, including the type of goals that are optimized and the equations for calculating fitness values
 - [ ] explicitly defines evaluated approaches, including the techniques, specific heuristics, and the parameters and their values<sup><a class="footnote footnote-ref">10</a></sup>
 - [ ] EITHER: clearly describes (and follows) a sound process to collect and prepare the datasets used to run and to evaluate the optimization approach  

--- a/form_generator/js/read_standards.js
+++ b/form_generator/js/read_standards.js
@@ -133,7 +133,7 @@ function readSpecificEmpiricalStandard_table(standard_name){
 //This function creates tooltips for text
 //Anything between / and / is known as regular expressions
 function createTooltip(checklistItemText, line_text, footnotes){
-	footnote_sups = line_text.match(/(.*?)\{sup\}.+?\[\d+\]\(#[\w\d_]+\)\{\/sup\}(.*?)/g);
+	footnote_sups = line_text.match(/(.*?)\{sup\}(.+?)\{\/sup\}(.*?)/g);
 	if(footnote_sups){
 		footnote_rest = line_text.match(/(?!.*\})(.*?)$/g);
 		footnote_rest = footnote_rest.filter(function (el) {
@@ -999,13 +999,16 @@ function convert_MD_standard_checklists_to_html_standard_checklists(standardName
 			// Change the text to the string held in line_text
 			checklistItemLI.setAttribute("text", line_text);
 
-			if(line_text.replaceAll("<br/><br>", "") == "")
+			if(line_text.replaceAll("<br/><br>", "") == "") {
 				continue;
-			if(line_text.includes("footnote"))
+			}
+			
+			if(line_text.includes("footnote")) {
 				checklistItemText = createTooltip(checklistItemText, line_text, footnotes);
-			else
+			} else {
 				checklistItemText.innerHTML = "&nbsp;" + line_text;
 				// ???????????????????? previous line does what?
+			}
 
 			//locate the current checklist into the table
 			data = dataStructure.get(Encode_key(line_text))
@@ -1261,7 +1264,7 @@ function collect_footnotes(dom, standardTag){
 
 	for(let footnoteTag of footnoteTags){
 		supTag = footnoteTag.getElementsByTagName("sup")[0];
-		footnote_id = standardTag.getAttribute('name')+"--"+supTag.innerText.trim() // To make footnotes belong to their standards
+		footnote_id = standardTag.getAttribute('name')+"--footnote--"+supTag.innerText.trim() // To make footnotes belong to their standards
 		supTag.remove();
 		footnotes[footnote_id] = footnoteTag.innerText.trim();
 	}
@@ -1459,7 +1462,7 @@ function create_requirements_checklist(file){
 		for (let checklistTag of checklistTags){
 
 			// dealing with footnotes
-			checklistHTML = checklistTag.innerHTML.replaceAll("<sup>", "<sup>"+standardName+"--") // To make footnotes belong to their standards 
+			checklistHTML = checklistTag.innerHTML.replaceAll("<sup>", "<sup>"+standardName+"--footnote--") // To make footnotes belong to their standards 
 			//console.log(checklistHTML)
 			// Add all information for "all_intro_items", etc.
 			separate_essential_attributes_based_on_IMRaD_tags(standardTag.getAttribute('name'), checklistTag.getAttribute('name'), checklistHTML)


### PR DESCRIPTION
Fixed the checklist generation so footnotes are now converted to tooltips properly

Example of the fix: https://eschltz.github.io/standardstest/form_generator/result.html?standard=Case+Study&standard=Grounded+Theory&standard=Systematic+Reviews&role=one-phase-reviewer