### PR TITLE
Add download errors for missing items on reviewer checklists

### DIFF
--- a/form_generator/css/appearance.css
+++ b/form_generator/css/appearance.css
@@ -36,6 +36,12 @@ form:active {
 	padding-left: 65px;
 }
 
+.error_warning {
+	color: red;
+	margin-top: 10px;
+	margin-bottom: 10px;
+}
+
 @media screen and (min-width: 401px) and (max-width: 785px)
 {
 	#container


### PR DESCRIPTION
When a reviewer tries to download a checklist without completing all the items in the checklist, a warning will now display and the missed items will be highlighted with red text.

Live example: https://eschltz.github.io/standardstest/form_generator/result.html?standard=Data+Science&role=one-phase-reviewer