### PR TITLE
Collapse cleared inputs on reviewer checklists

### DIFF
--- a/form_generator/js/RequirementsChecklist.js
+++ b/form_generator/js/RequirementsChecklist.js
@@ -415,18 +415,27 @@ function clear_checklist(event) {
 			}
 		}
 
-		// If author, hide deviation blocks and display primary location boxes
+		deviation_boxes = document.getElementsByClassName("question_block");
+
+		// If author, display primary location boxes
 		if (role == "\"author\"") {
 			primary_locations = document.getElementsByClassName("item_location_textbox");
-			deviation_boxes = document.getElementsByClassName("question_block");
 
 			for (let location_box of primary_locations) {
 				location_box.style.visibility = "visible";
 			}
-
-			for (let deviation_box of deviation_boxes) {
-				deviation_box.style.display = "none";
+		} else {
+			// If reviewer, hide free text boxes
+			text_boxes = document.getElementsByClassName("question_block_free_Text");
+			
+			for (let text_box of text_boxes) {
+				text_box.style.display = "none";
 			}
+		}
+		
+		// Hide deviation boxes
+		for (let deviation_box of deviation_boxes) {
+			deviation_box.style.display = "none";
 		}
 	}
 }


### PR DESCRIPTION
When a reviewer checklist is reset the inputs will now collapse instead of remaining visible but empty