### PR TITLE
Update Experiments.md on invalid criticism

### DIFF
--- a/docs/standards/Experiments.md
+++ b/docs/standards/Experiments.md
@@ -118,6 +118,7 @@ objectivity, reproducibility
 -   the reviewer would have investigated the topic in any other way than
     an experiment
 -   not enough participants (unless supported by power analysis)
+-   not employing an incentivization scheme
 
 ## Exemplars
 


### PR DESCRIPTION
There are many reasons for not using financial incentives, including that the experiment does not involve effort or that there is simply no money available. The non-use of financial incentives should be reported though.