### PR TITLE
Fix checklist formatting for "Extraordinary Attributes" section in longitudinal

### DIFF
--- a/docs/standards/Longitudinal.md
+++ b/docs/standards/Longitudinal.md
@@ -62,8 +62,8 @@ For cross-sectional analysis, consider the **Exploratory Data Science Standard**
 <checklist name="Extraordinary">
 
 - [ ] uses a multi-stage selection process to identify the study's subjects<sup><a class="footnote footnote_ref">9</a></sup>
-</checklist>
-- [ ] follows subjects for an exceptionally long period (e.g. more than five years)    
+- [ ] follows subjects for an exceptionally long period (e.g. more than five years)
+</checklist>    
 
 ## General Quality Criteria
 


### PR DESCRIPTION
## Problem
The second checklist item "follows subjects for an exceptionally long period" was rendering outside of the checklist component due to incorrect placement after the closing `</checklist>` tag.

## Solution
Moved the second checklist item inside the `<checklist>` component to ensure both items render properly as part of the same checklist.