### PR TITLE
Make GroundedTheory.md adequate to GTM

### DIFF
--- a/docs/standards/GroundedTheory.md
+++ b/docs/standards/GroundedTheory.md
@@ -58,6 +58,7 @@ collection and analysis or do not use theoretical sampling, consider the
 - [ ]	provides supplemental materials such as interview guide(s), coding schemes, coding examples, decision rules, or extended chain-of-evidence tables
 - [ ]	results involve relationships between the concepts ("pushing to theory", not stopping with unconnected themes)
 - [ ]	a diagram provides an overview of the main concepts and relationships
+- [ ]	shows the mapping from categories to lower-level codes and concepts to observations (e.g. as a table)
 - [ ]	explains how and why study deviates from claimed GT variant and/or how variants were combined
 - [ ]	includes data representing a diverse (rather than homogeneous) spectrum of people or things
 - [ ]	explains how memo writing was used to drive the work


### PR DESCRIPTION
`GroundedTheory.md` is currently misleading and lets some reviewers make truly horrible comments.

The PR touches the majority of the items, including some complete deletions, some item additions, and many rewordings (some major, many just at a polishing level).
For details, see the extensive commit messages of the individual commits.