### PR TITLE
Add link to GitHub issues

### DIFF
--- a/form_generator/css/appearance.css
+++ b/form_generator/css/appearance.css
@@ -195,7 +195,7 @@ form:active {
 	padding-bottom: 20px;
 }
 
-.standard_links {
+.standard_links, .github_links {
 	font-size: 16px;
 	background-color: #dedee4;
 	padding: 5px;
@@ -203,6 +203,10 @@ form:active {
 	color: black;
 	margin: 10px;
 	line-height: 3em;
+}
+
+.github_links {
+	
 }
 
 #clear_container {

--- a/form_generator/css/appearance.css
+++ b/form_generator/css/appearance.css
@@ -205,10 +205,6 @@ form:active {
 	line-height: 3em;
 }
 
-.github_links {
-	
-}
-
 #clear_container {
 	text-align: end;
 }

--- a/form_generator/js/ReadStandards.js
+++ b/form_generator/js/ReadStandards.js
@@ -202,6 +202,36 @@ function createForMoreInfoPart(standardKeys) {
 	return moreInfoContainer;
 }
 
+// Add the dynamic Github link
+function createGithubLink(standardKeys) {
+	var githubLinkContainer = document.createElement("DIV");
+	var githubLink = document.createElement("a");
+	githubLink.innerHTML = "Report a problem with this checklist.";
+	
+	var github = "https://github.com/acmsigsoft/EmpiricalStandards/issues/new?";
+	var labelList = "labels=";
+	
+	// Get all labels
+	for (let key of standardKeys) {
+		let label = key.replaceAll(" ", "");
+		label = label.replaceAll("\"", "");
+		console.log(label);
+		
+		if (label != "GeneralStandard") {
+			label += "Standard";
+		}
+		labelList += label + ",";
+	}
+	
+	// Build link
+	githubLink.href = github + labelList + "&assignees=drpaulralph&body=Describe+the+issue.";
+	githubLink.target = "_blank";
+	githubLink.className = "github_links";
+	
+	githubLinkContainer.appendChild(githubLink);
+	return githubLinkContainer;
+}
+
 // Functions below are directly accessed by the UI Files
 function generateStandardChecklist(file) {
 	console.log(file);
@@ -242,6 +272,12 @@ function generateStandardChecklist(file) {
 	// Create "For more information, see:"
 	var moreInfoContainer = createForMoreInfoPart(standardKeys);
 	container.appendChild(moreInfoContainer);
+	
+	// Add dynamic link to GitHub issues
+	HR = document.createElement("HR");
+	container.appendChild(HR);
+	var githubLink = createGithubLink(standardKeys);
+	container.appendChild(githubLink);
 
 	if (wrapper == null) {
 		document.body.appendChild(container);


### PR DESCRIPTION
A link to submit a new GitHub issue has been added to the bottom of each checklist so users can report problems and provide feedback. Issue labels are automatically chosen based on the standards used (issue #180)